### PR TITLE
Creating Books and Rendering User Books Works Again

### DIFF
--- a/events/formEvents.js
+++ b/events/formEvents.js
@@ -24,7 +24,7 @@ const formEvents = (user) => {
         const patchPayload = { firebaseKey: name };
 
         updateBook(patchPayload).then(() => {
-          getBooks(user.id).then(showBooks);
+          getBooks(user.uid).then(showBooks);
         });
       });
     }


### PR DESCRIPTION
Creating a book works as it should on the client. The page renders the user's books after the payload is sent to Firebase.